### PR TITLE
Task/bam 161 release from an input tag in anywhere

### DIFF
--- a/.github/workflows/dotnet8-deploy.yml
+++ b/.github/workflows/dotnet8-deploy.yml
@@ -1,6 +1,11 @@
 name: .NET8 Build and Release
 on:
   workflow_dispatch:
+    inputs:
+      kp_tag:
+        description: 'Optional tag for kp-protocols-clientsdk'
+        required: false
+        default: ''
 
 jobs:
   tagging:
@@ -10,21 +15,27 @@ jobs:
       version: ${{ steps.tag.outputs.version }}
       prerelease: ${{ steps.tag.outputs.prerelease }}
     steps:
-      - name: Fetch head tag from kp-protocols-clientsdk
+      - name: Fetch version tag from kp-protocols-clientsdk
         id: tag
         run: |
-          git clone --branch main https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
-          cd proto-repo
-          head_tag=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
-          if [[ -z "${head_tag}" ]]; then
+          if [ -n "${{ github.event.inputs.kp_tag }}" ]; then
+            git clone https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
+            cd proto-repo
+            git checkout tags/${{ github.event.inputs.kp_tag }} -b temp-branch
+            version_tag=${{ github.event.inputs.kp_tag }}
+          else
+            git clone --branch main https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
+            cd proto-repo
+            version_tag=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
+          fi
+          if [[ -z "${version_tag}" ]]; then
             echo "No tag found on the head commit of kp-protocols-clientsdk repo. Failing the action."
             exit 1
           else
-            echo "tag=${head_tag}" >> $GITHUB_OUTPUT
-            echo "version=${head_tag#v}" >> $GITHUB_OUTPUT
-            if [[ "${head_tag}" == *-* ]]; then echo "prerelease=true" >> $GITHUB_OUTPUT; else echo "prerelease=false" >> $GITHUB_OUTPUT; fi
+            echo "tag=${version_tag}" >> $GITHUB_OUTPUT
+            echo "version=${version_tag#v}" >> $GITHUB_OUTPUT
+            if [[ "${version_tag}" == *-* ]]; then echo "prerelease=true" >> $GITHUB_OUTPUT; else echo "prerelease=false" >> $GITHUB_OUTPUT; fi
           fi
-
   tagging-echo:
     needs:
       - tagging

--- a/.github/workflows/dotnet8-deploy.yml
+++ b/.github/workflows/dotnet8-deploy.yml
@@ -65,9 +65,10 @@ jobs:
               Write-Error "Failed to checkout tag $env:GITHUB_EVENT_INPUTS_KP_TAG"
               exit 1
             }
+          } else {
+            Write-Output "Environment variable GITHUB_EVENT_INPUTS_KP_TAG does not have a value."
           }
           cd ..
-        shell: pwsh
 
       - name: Setup dotnet
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/dotnet8-deploy.yml
+++ b/.github/workflows/dotnet8-deploy.yml
@@ -58,11 +58,16 @@ jobs:
       - name: Checkout proto repository
         run: |
           git clone https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
-          cd proto-repo || { echo "Failed to change directory to proto-repo"; exit 1; }
-          if [ -n "${{ github.event.inputs.kp_tag }}" ]; then
-            git checkout tags/${{ github.event.inputs.kp_tag }} -b temp-branch || { echo "Failed to checkout tag ${{ github.event.inputs.kp_tag }}"; exit 1; }
-          fi
+          cd proto-repo
+          if ($env:GITHUB_EVENT_INPUTS_KP_TAG) {
+            git checkout tags/$env:GITHUB_EVENT_INPUTS_KP_TAG -b temp-branch
+            if ($LASTEXITCODE -ne 0) {
+              Write-Error "Failed to checkout tag $env:GITHUB_EVENT_INPUTS_KP_TAG"
+              exit 1
+            }
+          }
           cd ..
+        shell: pwsh
 
       - name: Setup dotnet
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/dotnet8-deploy.yml
+++ b/.github/workflows/dotnet8-deploy.yml
@@ -58,6 +58,11 @@ jobs:
       - name: Checkout proto repository
         run: |
           git clone https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
+          cd proto-repo
+          if [ -n "${{ github.event.inputs.kp_tag }}" ]; then
+            git checkout tags/${{ github.event.inputs.kp_tag }} -b temp-branch
+          fi
+          cd ..
 
       - name: Setup dotnet
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/dotnet8-deploy.yml
+++ b/.github/workflows/dotnet8-deploy.yml
@@ -69,6 +69,8 @@ jobs:
             Write-Output "Environment variable GITHUB_EVENT_INPUTS_KP_TAG does not have a value."
           }
           cd ..
+        env:
+          GITHUB_EVENT_INPUTS_KP_TAG: ${{ github.event.inputs.kp_tag }}
 
       - name: Setup dotnet
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/dotnet8-deploy.yml
+++ b/.github/workflows/dotnet8-deploy.yml
@@ -83,7 +83,6 @@ jobs:
         run: dotnet pack --configuration Release -p:PackageVersion=${{ needs.tagging.outputs.version }} dotnet8
 
       - name: Publish to NuGet
-        if: ${{ needs.tagging.outputs.prerelease == 'false' }}
         run: dotnet nuget push --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json dotnet8\bin\Release\kody-dotnet8-client.*.nupkg
         # TODO: Sign package
 

--- a/.github/workflows/dotnet8-deploy.yml
+++ b/.github/workflows/dotnet8-deploy.yml
@@ -20,8 +20,8 @@ jobs:
         run: |
           if [ -n "${{ github.event.inputs.kp_tag }}" ]; then
             git clone https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
-            cd proto-repo
-            git checkout tags/${{ github.event.inputs.kp_tag }} -b temp-branch
+            cd proto-repo || { echo "Failed to change directory to proto-repo"; exit 1; }
+            git checkout tags/${{ github.event.inputs.kp_tag }} -b temp-branch || { echo "Failed to checkout tag ${{ github.event.inputs.kp_tag }}"; exit 1; }
             version_tag=${{ github.event.inputs.kp_tag }}
           else
             git clone --branch main https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
@@ -58,9 +58,9 @@ jobs:
       - name: Checkout proto repository
         run: |
           git clone https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
-          cd proto-repo
+          cd proto-repo || { echo "Failed to change directory to proto-repo"; exit 1; }
           if [ -n "${{ github.event.inputs.kp_tag }}" ]; then
-            git checkout tags/${{ github.event.inputs.kp_tag }} -b temp-branch
+            git checkout tags/${{ github.event.inputs.kp_tag }} -b temp-branch || { echo "Failed to checkout tag ${{ github.event.inputs.kp_tag }}"; exit 1; }
           fi
           cd ..
 

--- a/dotnet8/dotnet.csproj
+++ b/dotnet8/dotnet.csproj
@@ -18,6 +18,8 @@
 
     <ItemGroup>
         <Protobuf Include="../proto-repo/src/main/proto/com/kodypay/grpc/pay/v1/pay.proto" GrpcServices="Client" />
+        <Protobuf Include="../proto-repo/src/main/proto/com/kodypay/grpc/ordering/v1/inventory.proto" GrpcServices="Client" />
+        <Protobuf Include="../proto-repo/src/main/proto/com/kodypay/grpc/ordering/v1/order.proto" GrpcServices="Client" />
     </ItemGroup>
 
     <ItemGroup>

--- a/dotnet8/dotnet.csproj
+++ b/dotnet8/dotnet.csproj
@@ -14,11 +14,11 @@
         <RepositoryUrl>https://github.com/KodyPay/kody-clientsdk-dotnet</RepositoryUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <IncludeSymbols>true</IncludeSymbols>
+        <Deterministic>true</Deterministic>
     </PropertyGroup>
 
     <ItemGroup>
         <Protobuf Include="../proto-repo/src/main/proto/com/kodypay/grpc/pay/v1/pay.proto" GrpcServices="Client" />
-        <Protobuf Include="../proto-repo/src/main/proto/com/kodypay/grpc/ordering/v1/inventory.proto" GrpcServices="Client" />
         <Protobuf Include="../proto-repo/src/main/proto/com/kodypay/grpc/ordering/v1/order.proto" GrpcServices="Client" />
     </ItemGroup>
 
@@ -35,6 +35,5 @@
     <PropertyGroup>
         <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
         <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
-        <Deterministic>true</Deterministic>
     </PropertyGroup>
 </Project>

--- a/dotnet8/dotnet.csproj
+++ b/dotnet8/dotnet.csproj
@@ -10,8 +10,10 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <Company>KodyPay</Company>
         <PackageDescription>Kody .NET8 gRPC Client</PackageDescription>
+        <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/KodyPay/kody-clientsdk-dotnet</RepositoryUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <IncludeSymbols>true</IncludeSymbols>
     </PropertyGroup>
 
     <ItemGroup>
@@ -31,5 +33,6 @@
     <PropertyGroup>
         <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
         <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+        <Deterministic>true</Deterministic>
     </PropertyGroup>
 </Project>

--- a/dotnet8/dotnet.csproj
+++ b/dotnet8/dotnet.csproj
@@ -10,11 +10,8 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <Company>KodyPay</Company>
         <PackageDescription>Kody .NET8 gRPC Client</PackageDescription>
-        <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/KodyPay/kody-clientsdk-dotnet</RepositoryUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <IncludeSymbols>true</IncludeSymbols>
-        <Deterministic>true</Deterministic>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
**What is the change for**

- For a new project, we may want to release an SDK with an alpha(prerelease) version of our specification to our customers to gather early feedback. The alpha version of the specification might still be under review and reside in a task or feature branch.
- Additionally, for developers, it can be beneficial to release a prerelease version of the SDK. This allows them to begin working on a specification that hasn’t been fully finalized, especially in situations requiring urgent progress.


**What is changed**

- To be able to release the such sdk from an alpha version spec, the action from the sdk repo need to checkout the protobuf spec using a manual input tag.
- Also included new spec to be published for user to try

