### PR TITLE
BAM-165: add inventory spec for dotnet sdk

### DIFF
--- a/dotnet8/dotnet.csproj
+++ b/dotnet8/dotnet.csproj
@@ -17,6 +17,7 @@
     <ItemGroup>
         <Protobuf Include="../proto-repo/src/main/proto/com/kodypay/grpc/pay/v1/pay.proto" GrpcServices="Client" />
         <Protobuf Include="../proto-repo/src/main/proto/com/kodypay/grpc/ordering/v1/order.proto" GrpcServices="Client" />
+        <Protobuf Include="../proto-repo/src/main/proto/com/kodypay/grpc/ordering/v1/inventory.proto" GrpcServices="Client" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
**JIRA**

BAM-165

**What does the change do**

Including inventory spec for dot net SDK generation. Previously, we did not include it as the spec has not been merged into main branch of protocols clientsdk 

